### PR TITLE
Fix unresolvable trivy/anchore action pins blocking the release build

### DIFF
--- a/.github/scripts/verify-action-pins.sh
+++ b/.github/scripts/verify-action-pins.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Verify every `uses: owner/repo[/subpath]@ref` in .github/workflows resolves to
+# a real remote tag or branch.
+#
+# Why this exists: the publish job (build-and-push in docker-image.yml) only runs
+# on push to `main`, so a bad action pin in it is never resolved by PR CI and
+# only fails after merge — which is exactly how `trivy-action@0.36.0` (should be
+# v0.36.0) and `anchore/scan-action@v7` (no moving v7 tag) shipped broken. This
+# check runs on PRs and catches that class of failure before merge.
+#
+# Uses the GitHub API via `gh` (authenticated in CI through GITHUB_TOKEN) so it
+# doesn't hit the anonymous rate limits that make bare `git ls-remote` flaky.
+# Local `./...` uses and 40-char commit-SHA pins are skipped.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WF_DIR="$ROOT/.github/workflows"
+
+fail=0
+declare -A seen
+
+# Only match genuine `uses:` mapping keys (optionally list items), never `uses:`
+# appearing inside comment prose — anchor to start-of-line + optional "- ".
+mapfile -t refs < <(
+  grep -rhE '^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]' "$WF_DIR"/*.yml \
+    | sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+//' \
+    | sed -E 's/[[:space:]]*#.*$//' \
+    | tr -d '"'"'"'' \
+    | sort -u
+)
+
+for ref in "${refs[@]}"; do
+  [[ -z "$ref" ]] && continue
+  [[ "$ref" == ./* ]] && continue            # local composite action
+  [[ "$ref" != *@* ]] && continue            # docker://… or malformed; skip
+  [[ -n "${seen[$ref]:-}" ]] && continue
+  seen[$ref]=1
+
+  action="${ref%@*}"
+  tag="${ref##*@}"
+  repo="$(cut -d/ -f1,2 <<<"$action")"
+
+  if [[ "$tag" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "SKIP  $ref  (SHA pin)"
+    continue
+  fi
+
+  if gh api "repos/$repo/git/ref/tags/$tag" >/dev/null 2>&1 \
+     || gh api "repos/$repo/git/ref/heads/$tag" >/dev/null 2>&1; then
+    echo "OK    $ref"
+  else
+    echo "FAIL  $ref  (no tag or branch '$tag' in $repo)"
+    fail=1
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  echo ""
+  echo "One or more action pins do not resolve to a real tag/branch. Fix the pin"
+  echo "(check the action's releases for the exact tag, incl. any 'v' prefix)."
+  exit 1
+fi
+echo ""
+echo "All action pins resolve."

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -150,7 +150,7 @@ jobs:
         cache-from: type=gha
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.36.0
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: lusky3/bastillion:scan
         format: sarif
@@ -165,7 +165,7 @@ jobs:
 
     - name: Run Grype vulnerability scanner
       id: grype
-      uses: anchore/scan-action@v7
+      uses: anchore/scan-action@v7.4.0
       with:
         image: lusky3/bastillion:scan
         fail-build: false

--- a/.github/workflows/verify-action-pins.yml
+++ b/.github/workflows/verify-action-pins.yml
@@ -1,0 +1,24 @@
+name: Verify Action Pins
+
+# Catches unresolvable action pins on PRs. The publish job that references most
+# actions only runs on push to main, so this lightweight check is what surfaces
+# a bad `uses: ...@tag` before it merges and breaks the release build.
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/verify-action-pins.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify every action pin resolves
+        run: ./.github/scripts/verify-action-pins.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The action-version bump in #22 used tags that don't exist, and it only surfaced after merge because the `build-and-push` job (which references these actions) runs on push to `main`, not on PRs — so the bad refs were never resolved until #22 landed. Result: the v5 image failed to publish and `latest` is still the old pre-v5 build.

Fixes:
- `aquasecurity/trivy-action@0.36.0` → `@v0.36.0` (this action's tags are v-prefixed)
- `anchore/scan-action@v7` → `@v7.4.0` (no moving `v7` tag exists; only point releases)

Both target tags verified present via the GitHub API. Merging this re-runs `build-and-push` on main, which is the real test (it can't run on this PR).

Note: this is why the failure slipped through — PR CI never exercises the publish job. Worth considering a `workflow_dispatch` or a lint step that resolves action refs on PRs, as a follow-up.