### PR TITLE
Fix upstream auto-sync (master→main) and publish version image tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -121,6 +121,14 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_KEY }}
 
+    - name: Derive version tags from pom
+      id: ver
+      run: |
+        # Project version is the first <version> in pom.xml (5.0.1-SNAPSHOT -> 5.0.1)
+        V=$(grep -m1 '<version>' pom.xml | sed -E 's/.*<version>([^<]+)<.*/\1/' | sed 's/-SNAPSHOT//')
+        echo "major=${V%%.*}" >> "$GITHUB_OUTPUT"
+        echo "minor=$(echo "$V" | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v6
@@ -133,6 +141,8 @@ jobs:
           type=ref,event=pr
           type=sha,prefix={{branch}}-
           type=raw,value=latest,enable={{is_default_branch}}
+          type=raw,value=${{ steps.ver.outputs.minor }},enable={{is_default_branch}}
+          type=raw,value=${{ steps.ver.outputs.major }},enable={{is_default_branch}}
         annotations: |
           org.opencontainers.image.title=Bastillion
           org.opencontainers.image.description=Web-based SSH console that centrally manages administrative access to systems with key management and two-factor authentication

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -31,16 +31,16 @@ jobs:
       - name: Check for updates
         id: check
         run: |
-          # Check if there are commits in upstream/master that aren't in main
+          # Check if there are commits in upstream/main that aren't in main
           # This accounts for diverged histories and cherry-picks
-          COMMITS_TO_MERGE=$(git rev-list --count HEAD..upstream/master)
+          COMMITS_TO_MERGE=$(git rev-list --count HEAD..upstream/main)
           
           if [ "$COMMITS_TO_MERGE" -eq 0 ]; then
             echo "No new commits to merge from upstream"
             echo "has_updates=false" >> $GITHUB_OUTPUT
           else
             echo "Found $COMMITS_TO_MERGE commits to merge from upstream"
-            LATEST_UPSTREAM=$(git rev-parse upstream/master)
+            LATEST_UPSTREAM=$(git rev-parse upstream/main)
             echo "has_updates=true" >> $GITHUB_OUTPUT
             echo "upstream_sha=${LATEST_UPSTREAM:0:7}" >> $GITHUB_OUTPUT
             echo "commits_count=$COMMITS_TO_MERGE" >> $GITHUB_OUTPUT
@@ -58,7 +58,7 @@ jobs:
         id: merge
         run: |
           # Merge with strategy to keep our workflows
-          if git merge upstream/master --no-edit -X ours; then
+          if git merge upstream/main --no-edit -X ours; then
             # Restore our workflows (keep ours, not upstream's)
             git checkout HEAD -- .github/workflows/
             


### PR DESCRIPTION
Two post-v5 follow-ups.

**1. Auto-sync was silently broken.** `sync-upstream.yml` referenced `upstream/master`, but upstream renamed its default branch to `main` during the v5 migration (confirmed: bastillion-io/Bastillion has only `main` now). `git rev-list HEAD..upstream/master` against a nonexistent ref made the daily sync a no-op, so upstream security fixes would stop flowing in. Repointed all four references to `upstream/main`.

**2. No pinnable version tag.** Releases published only `latest` + `main-<sha>`. Added a step that derives the project version from `pom.xml` and publishes moving `5` and `5.0` tags on default-branch builds, so users can pin `lusky3/bastillion:5` (or `:5.0`) instead of chasing `latest`. Kept them as line tags rather than `5.0.1` since the pom is a pre-release SNAPSHOT.

The new Verify Action Pins guard (from #23) runs on this PR since it touches workflows; no new pins were added. Note: the `build-and-push` tag change only takes effect on merge to main (main-only job), same as before.

Heads-up unrelated to this PR: the sync workflow merges upstream with `-X ours`, which silently resolves any conflict in the fork's favor — worth revisiting separately, but out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker image builds now publish additional major and minor version tags on the default branch.

* **Bug Fixes**
  * Upstream synchronization now tracks the upstream `main` branch instead of `master`, improving compatibility with the current branch structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->