### PR TITLE
Rebuild image on upstream sync (fixes stale published image)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches:
       - main
+  # Allow manual/programmatic runs. The Sync Upstream workflow dispatches this
+  # after it auto-merges: its merge uses GITHUB_TOKEN, whose pushes do NOT
+  # trigger `push` workflows, so without this the image would never rebuild on
+  # an upstream sync. workflow_dispatch is the documented exception that DOES
+  # run when triggered via GITHUB_TOKEN.
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -133,3 +133,20 @@ jobs:
               pull_number: prNumber,
               merge_method: 'merge'
             });
+
+      - name: Trigger image build for the merged sync
+        # The merge above uses GITHUB_TOKEN, so its push does NOT trigger the
+        # `push`-based Build and Push Docker Image workflow (GitHub suppresses
+        # recursive GITHUB_TOKEN runs). Dispatch it explicitly so the published
+        # image actually picks up the synced upstream changes. workflow_dispatch
+        # is exempt from that suppression, so this run does fire.
+        if: steps.check.outputs.has_updates == 'true' && steps.merge.outputs.has_commits == 'true' && steps.merge.outputs.has_conflicts == 'false'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docker-image.yml',
+              ref: 'main',
+            });

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write   # required for createWorkflowDispatch (trigger image build after merge)
 
 jobs:
   sync:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ LABEL org.opencontainers.image.licenses="Prosperity-3.0.0"
 # curl: used by container healthchecks.
 # Acquire::Retries + timeouts: the Ubuntu apt mirrors intermittently time out on
 # CI runners, which was failing the build outright; retry transient fetch errors.
+# DL3008 (pin apt versions) is intentionally ignored: pinned Debian point-releases
+# get garbage-collected from the mirror, which breaks rebuilds — the opposite of
+# the reliability this line is here to provide.
+# hadolint ignore=DL3008
 RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update \
     && apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y --no-install-recommends openssh-client curl \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ LABEL org.opencontainers.image.licenses="Prosperity-3.0.0"
 # openssh-client: SSHUtil shells out to ssh-keygen to passphrase-encrypt generated
 # ed25519 keys — without it, keys are silently written unencrypted.
 # curl: used by container healthchecks.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssh-client curl \
+# Acquire::Retries + timeouts: the Ubuntu apt mirrors intermittently time out on
+# CI runners, which was failing the build outright; retry transient fetch errors.
+RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update \
+    && apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y --no-install-recommends openssh-client curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 999 bastillion \


### PR DESCRIPTION
## Problem

`main` is current with upstream (incl. #27's security fixes: unauthenticated admin bypass, WS terminal auth, login throttling, upload path traversal), **but the published image is not** — `latest`/`5`/`5.1` are still revision `209ea5c`, missing those fixes.

**Root cause:** `sync-upstream.yml` auto-merges its PR with `github.rest.pulls.merge()` using `GITHUB_TOKEN`. GitHub deliberately does not trigger `push`-based workflows from a `GITHUB_TOKEN` push, so `docker-image.yml` never ran for #27's merge. Every auto-sync updates `main` but silently leaves the image stale.

## Fix

- **docker-image.yml**: add `workflow_dispatch`. Dispatch (and repository_dispatch) events are the documented exception — they *do* run even when triggered via `GITHUB_TOKEN`. The `build-and-push` job already runs whenever the event isn't `pull_request`, so a dispatch on `main` publishes normally (`latest`/`5`/`5.1`).
- **sync-upstream.yml**: after the auto-merge, `createWorkflowDispatch` on `docker-image.yml`@`main` so the synced changes actually get built and pushed.

## Bonus

Merging this PR the normal way (a non-GITHUB_TOKEN push) itself triggers a build, which **publishes current `main`** — i.e. it ships #27's security fixes to the image immediately. If for any reason it doesn't, once this is on `main` you can also run `gh workflow run docker-image.yml --ref main`.

Verified: action-pin guard passes on the edited workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for manually or programmatically triggering Docker image builds.
  * Automated Docker image publishing after successful upstream synchronization and merge operations.
  * Ensured images include the latest merged changes even when standard push triggers are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->