### PR TITLE
Scope dependabot to fork-owned deps (drop maven, retarget npm to /tests)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,19 @@
 version: 2
+# Only scope dependabot to FORK-OWNED dependencies. The Maven pom and the root
+# package.json track upstream (bastillion-io) verbatim, so their updates arrive
+# via the Sync Upstream workflow — not fork-side dependabot PRs, which drift from
+# upstream and fight the pristine-source design (e.g. #29 tried to push Jetty 12
+# ahead of upstream and broke the build).
 updates:
-- package-ecosystem: maven
-  directory: "/"
+# Fork's Playwright test harness (the root package.json is upstream's frontend build).
+- package-ecosystem: npm
+  directory: "/tests"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
   automerge: true
 
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  automerge: true
-  
+# Fork-owned CI workflows.
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Follow-up to closing #29. Dependabot was scoped to `maven` and `npm` at the repo root, but both the Maven pom and the **root** `package.json` track upstream (bastillion-io) verbatim. Fork-side bumps of those drift from upstream and fight the pristine-source design — #29 was the symptom (dependabot tried to push `jetty-server` to 12 while upstream is still on 11.0.26; only bumped one of four Jetty artifacts; its CI failed to compile).

Maven/frontend dependency updates already flow in through the **Sync Upstream** workflow, so fork-side dependabot on them is redundant and harmful.

Changes:
- **Remove the `maven` ecosystem** (pom tracks upstream).
- **Retarget `npm` from `/` to `/tests`** — `/tests` is the fork's Playwright harness; the root `package.json` is upstream's frontend build.
- **Keep `github-actions`** (workflows are fork-owned).

Fork-owned deps stay covered; upstream-tracked deps stop generating drifting PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to focus on fork-owned test dependencies.
  * Kept daily update checks and automatic merging for eligible updates.
  * Documented that root-level dependencies are managed through the upstream synchronization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->