### PR TITLE
Remove unsupported automerge key from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,9 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  automerge: true
 
 # Fork-owned CI workflows.
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "daily"
-  automerge: true


### PR DESCRIPTION
Addresses the CodeRabbit comment that was left unresolved when #30 merged: `automerge` is not a supported `dependabot.yml` key — dependabot has no such option, so it does nothing (native auto-merge requires GitHub settings + a separate action/workflow). It was pre-existing invalid config that #30 carried forward. Removing it from both ecosystem blocks; no functional change.